### PR TITLE
Include gstatic.cn in CSP

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="
         default-src 'none';
         style-src 'self' 'unsafe-inline' <%= csp_extra_source %>;
-        script-src 'self' 'unsafe-eval' https://www.recaptcha.net https://www.gstatic.com <%= csp_extra_source %>;
+        script-src 'self' 'unsafe-eval' https://www.recaptcha.net https://www.gstatic.com https://www.gstatic.cn <%= csp_extra_source %>;
         img-src * blob: data:;
         connect-src *;
         font-src 'self' data: <%= csp_extra_source %>;


### PR DESCRIPTION
If users in China use reCAPTCHA, Google will make reCAPTCHA load scripts from gstatic.cn instead of gstatic.com. However, gstatic.cn is not included in the CSP, which causes Chinese users to be unable to load the captcha when using SchildiChat.

-----------------------------------------------------------------------------

- [x] I agree to release my changes under this project's license
