### PR TITLE
Improve IRC layout for SchildiChat: fix placement of capital letters inside read receipts

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -395,6 +395,7 @@ $left-gutter: 64px;
         .mx_BaseAvatar > * {
             height: $font-14px !important;
             width: $font-14px !important;
+            line-height: $font-14px; /* override wildcard; fix alignment of capital letter inside read receipts */
             flex-shrink: 0; /* Prevents the avatar from shrinking (when mx_DisambiguatedProfile_displayName is long) */
         }
 
@@ -405,6 +406,7 @@ $left-gutter: 64px;
             .mx_BaseAvatar > * {
                 height: $font-16px !important; /* override the value specified above */
                 width: $font-16px !important; /* override the value specified above */
+                line-height: $font-16px; /* override wildcard; fix alignment of capital letter inside read receipts */
             }
         }
 


### PR DESCRIPTION
This is a follow-up to 18578fe4ac6838b2d70a4efb029a75ab24087dab (https://github.com/SchildiChat/element-web/pull/4)

|Before|After|
|----------|-------|
|![before](https://github.com/user-attachments/assets/10d007dd-3643-42ba-b0ba-23e6d75e7a10)|![after](https://github.com/user-attachments/assets/0af698b5-c326-4415-b1ae-8f600974a872)|

<!-- Please describe your awesome changes here -->

Since I'm not familiar with the workflow yet, I've created this PR against the branch for the latest release. Please let me know if there is anything I need to do.

-----------------------------------------------------------------------------

- [x] I agree to release my changes under this project's license
