### PR TITLE
Remove CSS declarations which change default scrollbar width

### DIFF
--- a/res/css/structures/_AutoHideScrollbar.pcss
+++ b/res/css/structures/_AutoHideScrollbar.pcss
@@ -10,6 +10,19 @@ Please see LICENSE files in the repository root for full details.
 html {
     scrollbar-color: $scrollbar-thumb-color transparent;
 }
+/* SC: disabled */
+/* scrollbar-width is not inherited (but -color is, why?!), */
+/* so declare it on every element */
+/*
+* {
+    scrollbar-width: thin;
+}
+
+::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+*/
 
 ::-webkit-scrollbar-thumb {
     border-radius: 3px;

--- a/res/css/structures/_AutoHideScrollbar.pcss
+++ b/res/css/structures/_AutoHideScrollbar.pcss
@@ -1,23 +1,14 @@
 /*
 Copyright 2018-2024 New Vector Ltd.
+Copyright 2024 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only
 Please see LICENSE files in the repository root for full details.
 */
 
-/* make any scrollbar grey and thin */
+/* make any scrollbar grey */
 html {
     scrollbar-color: $scrollbar-thumb-color transparent;
-}
-/* scrollbar-width is not inherited (but -color is, why?!), */
-/* so declare it on every element */
-* {
-    scrollbar-width: thin;
-}
-
-::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
 }
 
 ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Fixes https://github.com/SchildiChat/schildichat-desktop/issues/238

Setting the declaration "scrollbar-width: thin" has a legitimate accessibility concern, though doing so could have made sense previously for some reason. Let's prefer each OS and its desktop environments' setting over Element's aesthetic view.

See: https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width#accessibility

Before:

https://github.com/user-attachments/assets/670c97c9-cc93-4b99-8cc6-63bc9e44b64d

After:

https://github.com/user-attachments/assets/b8053e07-b942-4029-bebd-ad189f3b623f

Closes https://github.com/SchildiChat/matrix-react-sdk/pull/24



<!-- Please describe your awesome changes here -->

-----------------------------------------------------------------------------

- [x] I agree to release my changes under this project's license
