### PR TITLE
Replace "Element" with "SchildiChat" for branding

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -13,7 +13,7 @@
     "disable_login_language_selector": false,
     "disable_3pid_login": false,
     "force_verification": false,
-    "brand": "Element",
+    "brand": "SchildiChat",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",
     "integrations_widgets_urls": [

--- a/contribute.json
+++ b/contribute.json
@@ -1,13 +1,13 @@
 {
-    "name": "Element",
-    "description": "A glossy Matrix collaboration client for the web.",
+    "name": "SchildiChat",
+    "description": "A feature-rich messenger for Matrix based on Element with some extras and tweaks.",
     "repository": {
-        "url": "https://github.com/element-hq/element-web",
+        "url": "https://github.com/SchildiChat/schildichat-desktop",
         "license": "AGPL-3.0-only OR GPL-3.0-only"
     },
     "bugs": {
-        "list": "https://github.com/element-hq/element-web/issues",
-        "report": "https://github.com/element-hq/element-web/issues/new/choose"
+        "list": "https://github.com/SchildiChat/schildichat-desktop/issues",
+        "report": "https://github.com/SchildiChat/schildichat-desktop/issues/new/choose"
     },
-    "keywords": ["chat", "riot", "matrix"]
+    "keywords": ["chat", "schildichat", "matrix"]
 }

--- a/res/manifest.json
+++ b/res/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "Element",
-    "short_name": "Element",
+    "name": "SchildiChat",
+    "short_name": "SC",
     "display": "standalone",
     "theme_color": "#76CFA6",
     "start_url": "index.html",

--- a/src/SdkConfig.ts
+++ b/src/SdkConfig.ts
@@ -17,7 +17,7 @@ import { DeepReadonly, Defaultize } from "./@types/common";
 
 // see element-web config.md for docs, or the IConfigOptions interface for dev docs
 export const DEFAULTS: DeepReadonly<IConfigOptions> = {
-    brand: "Element",
+    brand: "SchildiChat",
     help_url: "https://element.io/help",
     help_encryption_url: "https://element.io/help#encryption",
     integrations_ui_url: "https://scalar.vector.im/",

--- a/src/async-components/structures/ErrorView.tsx
+++ b/src/async-components/structures/ErrorView.tsx
@@ -121,7 +121,7 @@ export const UnsupportedBrowserView: React.FC<{
     onAccept?(): void;
 }> = ({ onAccept }) => {
     const config = SdkConfig.get();
-    const brand = config.brand ?? "Element";
+    const brand = config.brand ?? "SchildiChat";
 
     const hasDesktopBuilds =
         config.desktop_builds?.available &&

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -645,7 +645,7 @@
         "stop_voice_message": "Stop recording",
         "voice_message_button": "Voice Message"
     },
-    "console_dev_note": "If you know what you're doing, Element is open-source, be sure to check out our GitHub (https://github.com/vector-im/element-web/) and contribute!",
+    "console_dev_note": "If you know what you're doing, SchildiChat is open-source, be sure to check out our GitHub (https://github.com/SchildiChat/schildichat-desktop/) and contribute!",
     "console_scam_warning": "If someone told you to copy/paste something here, there is a high likelihood you're being scammed!",
     "console_wait": "Wait!",
     "create_room": {
@@ -1039,11 +1039,11 @@
         "hs_blocked": "This homeserver has been blocked by its administrator.",
         "invalid_configuration_mixed_server": "Invalid configuration: a default_hs_url can't be specified along with default_server_name or default_server_config",
         "invalid_configuration_no_server": "Invalid configuration: no default server specified.",
-        "invalid_json": "Your Element configuration contains invalid JSON. Please correct the problem and reload the page.",
+        "invalid_json": "Your SchildiChat configuration contains invalid JSON. Please correct the problem and reload the page.",
         "invalid_json_detail": "The message from the parser is: %(message)s",
         "invalid_json_generic": "Invalid JSON",
         "mau": "This homeserver has hit its Monthly Active User limit.",
-        "misconfigured": "Your Element is misconfigured",
+        "misconfigured": "Your SchildiChat is misconfigured",
         "mixed_content": "Can't connect to homeserver via HTTP when an HTTPS URL is in your browser bar. Either use HTTPS or <a>enable unsafe scripts</a>.",
         "non_urgent_echo_failure_toast": "Your server isn't responding to some <a>requests</a>.",
         "resource_limits": "This homeserver has exceeded one of its resource limits.",

--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -2,7 +2,7 @@
 <html lang="en" style="height: 100%;">
   <head>
     <meta charset="utf-8">
-    <title>Element</title>
+    <title>SchildiChat</title>
     <link rel="apple-touch-icon" sizes="57x57" href="<%= require('../../res/vector-icons/apple-touch-icon-57.png') %>">
     <link rel="apple-touch-icon" sizes="60x60" href="<%= require('../../res/vector-icons/apple-touch-icon-60.png') %>">
     <link rel="apple-touch-icon" sizes="72x72" href="<%= require('../../res/vector-icons/apple-touch-icon-72.png') %>">
@@ -16,8 +16,8 @@
     <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon" href="<%= require('../../res/vector-icons/favicon.ico') %>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="apple-mobile-web-app-title" content="Element">
-    <meta name="application-name" content="Element">
+    <meta name="apple-mobile-web-app-title" content="SchildiChat">
+    <meta name="application-name" content="SchildiChat">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-TileImage" content="<%= require('../../res/vector-icons/mstile-150.png') %>">
     <meta name="msapplication-config" content="<%= require('../../res/vector-icons/browserconfig.xml') %>">
@@ -58,7 +58,7 @@
 
   </head>
   <body style="height: 100%; margin: 0;">
-    <noscript>Sorry, Element requires JavaScript to be enabled.</noscript> <!-- TODO: Translate this? -->
+    <noscript>Sorry, SchildiChat requires JavaScript to be enabled.</noscript> <!-- TODO: Translate this? -->
     <div id="matrixchat" style="height: 100%;" class="notranslate"></div>
 
 <%


### PR DESCRIPTION
<!-- Please describe your awesome changes here -->

This PR intends to replace "Element" with "SchildiChat" for branding. While there are other changes which should be taken care of, such as URLs to SchildiChat Android etc., this PR does not touch them.

Note: please feel free to hijack this PR and add other changes as you would like.

-----------------------------------------------------------------------------

- [x] I agree to release my changes under this project's license
